### PR TITLE
Correct link for slack invite to use HTTP

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
             <ul class="nav navbar-nav menu_nav justify-content-end">
               <li class="nav-item active"><a class="nav-link" href="/">Home</a></li> 
-              <li class="nav-item"><a class="nav-link" href="https://slack.masoniteproject.com">Slack</a></li> 
+              <li class="nav-item"><a class="nav-link" href="http://slack.masoniteproject.com">Slack</a></li> 
               <li class="nav-item"><a class="nav-link" href="https://github.com/MasoniteFramework/masonite">GitHub</a>
               <li class="nav-item"><a class="nav-link" href="https://github.com/MasoniteFramework/core">GitHub Core</a>
             </ul>


### PR DESCRIPTION
I corrected the link for Slack invite tu use HTTP as the Slack server is not HTTP ready for now.
Linked to https://github.com/MasoniteFramework/masonite/issues/175
